### PR TITLE
docs: correct drift across command, guide, and contributor docs

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -10,6 +10,7 @@ This document describes the primary commands available in the Wild Pets plugin.
 - [Pet Information](#pet-information)
 - [Pet Behavior](#pet-behavior)
 - [Pet Management](#pet-management)
+- [Trading](#trading)
 - [Locking](#locking)
 - [Access Control](#access-control)
 - [Administration](#administration)
@@ -85,7 +86,7 @@ The main command can be accessed using either of the following aliases:
 **Usage:** `/wp follow`
 
 ### `/wp stay`
-**Permission:** `wp.stay` (must be explicitly granted; not defined in `plugin.yml` by default)  
+**Permission:** `wp.stay` (not defined in `plugin.yml`; operators have it by default, other players must be granted it explicitly)  
 **Description:** Commands your selected pet to stay in its current location.  
 **Usage:** `/wp stay`
 
@@ -116,6 +117,13 @@ The main command can be accessed using either of the following aliases:
 **Description:** Releases your currently selected pet, removing it from your ownership.  
 **Usage:** `/wp setfree`
 
+## Trading
+
+### `/wp trade <playerName>`
+**Permission:** `wp.trade` (default: true)  
+**Description:** Transfers ownership of your currently selected pet to another online player. The target player must be online, must not be yourself, and must be below the `petLimit`; you must also own the selected pet. Once the trade succeeds, the pet is removed from your pet list, your selection is cleared, and both players are notified.  
+**Usage:** `/wp trade PlayerName`
+
 ## Locking
 
 ### `/wp lock`
@@ -131,7 +139,7 @@ The main command can be accessed using either of the following aliases:
 ## Access Control
 
 ### `/wp checkaccess`
-**Permission:** `wp.checkaccess`  
+**Permission:** `wp.checkaccess` (not defined in `plugin.yml`; operators have it by default, other players must be granted it explicitly)  
 **Description:** Enters access-check mode. Right-click a pet to view who has access to it.  
 **Usage:** `/wp checkaccess`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Thank you for being interested in contributing to the project! It wouldn't be wh
 - Open the project in your preferred text editor or IDE.
 - Try compiling the plugin using the following command:
   ```bash
-  gradlew build
+  mvn clean package
   ```
   If you encounter any errors, please create an issue for it.
 
@@ -32,22 +32,22 @@ Work items are organized into milestones, which represent a specific version of 
 
 ## Making Changes
 - Before you start working on something, make sure there is an issue for it. If there isn't, create one.
-- Make sure you are working on the "develop" branch. If you are not, switch to it using `git checkout develop`.
+- Make sure you are working on the "main" branch. If you are not, switch to it using `git checkout main`.
 - Create a new branch for your changes using `git checkout -b <branch-name>`. Make sure to name your branch something that is related to the issue you are working on.
 - Make your changes to the code.
 - Test your changes to make sure they work as expected. [More information on testing can be found here](#testing).
 - When you are finished, commit your changes using `git commit -m "Your commit message here"`.
 - Push your changes to your fork using `git push origin <branch-name>`.
-- Open a pull request on the original repository. Make sure to include a description of your changes and link the related issue using #(number). The develop branch should be used as the base branch.
+- Open a pull request on the original repository. Make sure to include a description of your changes and link the related issue using #(number). The main branch should be used as the base branch.
 - Wait for your pull request to be reviewed. If there are any changes that need to be made, make them and push the changes to your fork. Your pull request will be updated automatically.
-- Once your pull request has been reviewed and approved, it will be merged into the develop branch.
+- Once your pull request has been reviewed and approved, it will be merged into the main branch.
 
 ## Testing
 1. Ensure docker is installed.
 2. Reopen the project in the provided dev container with the following commands:
 ```
-sudo cd ./.devcontainer
-sudo ./start_dev_container
+cd ./.devcontainer
+./start_dev_container.sh
 ```
 3. Run `mvn test`.
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Please fill out a bug report [here](https://github.com/dmccoystephenson/Wild-Pet
 1. Ensure docker is installed.
 2. Reopen the project in the provided dev container with the following commands:
 ```
-sudo cd ./.devcontainer
-sudo ./start_dev_container
+cd ./.devcontainer
+./start_dev_container.sh
 ```
 3. Run `mvn test`.
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -12,6 +12,7 @@ This guide provides step-by-step instructions for common scenarios and getting s
   - [Managing Multiple Pets](#managing-multiple-pets)
   - [Locating a Pet](#locating-a-pet)
   - [Locking a Pet](#locking-a-pet)
+  - [Trading a Pet](#trading-a-pet)
   - [Releasing a Pet](#releasing-a-pet)
 - [Tips and Best Practices](#tips-and-best-practices)
 - [Troubleshooting](#troubleshooting)
@@ -191,6 +192,25 @@ Wild Pets allows you to:
    ```
 
 2. **Right-click one of your owned pets** to unlock it.
+
+---
+
+### Trading a Pet
+
+**Goal:** Give one of your pets to another player.
+
+**Steps:**
+
+1. **Select the pet** you want to trade away (see [Selecting a Pet](#selecting-a-pet)).
+
+2. **Trade the pet** to an online player:
+   ```
+   /wp trade PlayerName
+   ```
+
+3. **Both players are notified** once the trade succeeds. The pet leaves your pet list, your selection is cleared, and the pet counts against the other player's pet limit from then on.
+
+> Note: The target player must be online, and you cannot trade a pet to yourself. A trade is also refused when the other player has already reached the `petLimit`. Ownership transfers immediately and cannot be undone by the plugin — the new owner has to trade the pet back.
 
 ---
 


### PR DESCRIPTION
## Summary

A documentation accuracy sweep was performed against the current source, and the following drift was corrected:

- **`/wp trade` was entirely undocumented.** The command is registered in `WildPets.java:164`, carries a `wp.trade` node in `src/main/resources/plugin.yml`, and is advertised by `/wp help` — but neither `COMMANDS.md` nor `USER_GUIDE.md` mentioned it. A `Trading` section has been added to `COMMANDS.md` and a `Trading a Pet` scenario to `USER_GUIDE.md`, both with TOC entries. The documented preconditions (target online, not self, ownership re-check, recipient below `petLimit`) were traced through `TradeCommand.execute` and `PetListRepository.transferPet`.
- **`wp.checkaccess` is not registered in `plugin.yml`.** `CheckAccessCommand` requires it and `PermissionChecker` calls `sender.hasPermission(...)`, so undefined nodes fall back to op-only. That gap is now annotated in `COMMANDS.md` the way `wp.stay` already was, and both wordings were made precise about the operator fallback (previously "must be explicitly granted", which omitted that operators receive it automatically).
- **`CONTRIBUTING.md` instructed contributors to build with `gradlew build`.** No Gradle wrapper exists in the repository; the project is built with Maven (`pom.xml`, `compile.sh`). The command was corrected to `mvn clean package`.
- **`CONTRIBUTING.md` directed contributions at a `develop` branch.** No such branch exists on the remote and the default branch is `main`; the three references were updated.
- **The dev container instructions in `README.md` and `CONTRIBUTING.md` were not runnable.** `sudo cd` is not valid (`cd` is a shell builtin) and the script is named `start_dev_container.sh`, not `start_dev_container`.

No production code was changed — per this loop's documentation-sweep rules, code-side findings are filed as issues rather than fixed under a docs cycle.

## Test plan

- [x] `mvn test` — 32 tests, 0 failures (run before the docs edits; no source files are touched by this PR, so the suite is unaffected)
- [x] Every claim added was verified against the source it describes (`TradeCommand`, `PetListRepository.transferPet`, `PermissionChecker`, `CommandService`, `plugin.yml`, `compile.sh`, `.devcontainer/start_dev_container.sh`)
- [x] `git ls-remote --heads origin` was used to confirm no `develop` branch exists
- [x] Every new TOC entry resolves to a heading added in the same file

## Deferred backlog

No open issue was picked up this cycle; all five remaining issues (#249, #250, #258, #265, #283) are feature requests that exceed the scope of a polish-sized PR and none had a documentation component. They are deferred, not rejected.

## Notes

No tracking issue — the drift was found during triage.

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->