### PR TITLE
chore: release version 2.0.0-SNAPSHOT-8-8-2026

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dansplugins</groupId>
     <artifactId>WildPets</artifactId>
-    <version>1.8.0</version>
+    <version>2.0.0-SNAPSHOT-8-8-2026</version>
     <packaging>jar</packaging>
 
     <name>Wild Pets</name>


### PR DESCRIPTION
## Summary

The version has been bumped from `1.8.0` to `2.0.0-SNAPSHOT-8-8-2026` in `pom.xml`.

The bump marks Wild-Pets moving to an AI-first development approach: day-to-day feature work,
grooming, review and maintenance now run through AI agents working directly against this
repository, with the maintainers setting direction and approving what lands.

It is not a compatibility break. Behaviour, configuration and stored data are unchanged, and
existing installations can upgrade in place — the version marks a change in how the project is
built, not in what it does.

## Snapshot designation

The dated snapshot designation follows the precedent set by Medieval Factions'
`6.0.0-SNAPSHOT-7-25-2026`: the AI-first line has not yet been verified in live operation, and
the designation stays until it has.

## Notes

This is part of a garden-wide pass applying the same bump across every project tended by
Gardener. Only version metadata has been changed; no functional code was touched.

---
*Drafted by Claude on behalf of Daniel Stephenson.*
