### PR TITLE
Add checkaccess and stats subcommands to /wp help output

### DIFF
--- a/src/main/java/dansplugins/wildpets/commands/HelpCommand.java
+++ b/src/main/java/dansplugins/wildpets/commands/HelpCommand.java
@@ -47,9 +47,11 @@ public class HelpCommand extends AbstractPluginCommand {
         player.sendMessage(MessageFormat.line(ChatColor.AQUA + "/wp locate " + ChatColor.GRAY + "- Locate your selected pet."));
         player.sendMessage(MessageFormat.line(ChatColor.AQUA + "/wp lock " + ChatColor.GRAY + "- Lock your pet."));
         player.sendMessage(MessageFormat.line(ChatColor.AQUA + "/wp unlock " + ChatColor.GRAY + "- Unlock your pet."));
+        player.sendMessage(MessageFormat.line(ChatColor.AQUA + "/wp checkaccess " + ChatColor.GRAY + "- Check who has access to a pet."));
         player.sendMessage(MessageFormat.line(ChatColor.AQUA + "/wp setfree " + ChatColor.GRAY + "- Set your pet free."));
         player.sendMessage(MessageFormat.line(ChatColor.AQUA + "/wp trade (playerName) " + ChatColor.GRAY + "- Trade selected pet to another player."));
         player.sendMessage(MessageFormat.line(ChatColor.AQUA + "/wp gather " + ChatColor.GRAY + "- Gather your pets in one place."));
+        player.sendMessage(MessageFormat.line(ChatColor.AQUA + "/wp stats " + ChatColor.GRAY + "- View plugin statistics."));
         player.sendMessage(MessageFormat.line(ChatColor.AQUA + "/wp config " + ChatColor.GRAY + "- View or set config options."));
         player.sendMessage(MessageFormat.footer());
         return true;

--- a/src/test/java/dansplugins/wildpets/commands/HelpCommandTest.java
+++ b/src/test/java/dansplugins/wildpets/commands/HelpCommandTest.java
@@ -1,0 +1,110 @@
+package dansplugins.wildpets.commands;
+
+import dansplugins.wildpets.config.ConfigService;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class HelpCommandTest {
+    @Mock
+    private ConfigService mockConfigService;
+
+    @Mock
+    private Player mockPlayer;
+
+    @Mock
+    private CommandSender mockConsoleSender;
+
+    private HelpCommand helpCommand;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        helpCommand = new HelpCommand(mockConfigService);
+    }
+
+    private List<String> captureMessagesSentToPlayer() {
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(mockPlayer, atLeastOnce()).sendMessage(captor.capture());
+        return captor.getAllValues();
+    }
+
+    private void assertListsSubcommand(List<String> messages, String subcommand) {
+        boolean found = messages.stream().anyMatch(message -> message.contains(subcommand + " "));
+        assertTrue("Expected /wp help to list '" + subcommand + "'", found);
+    }
+
+    @Test
+    public void testExecuteListsCheckAccessSubcommand() {
+        when(mockConfigService.getBoolean("rightClickToSelect")).thenReturn(true);
+
+        assertTrue(helpCommand.execute(mockPlayer));
+
+        assertListsSubcommand(captureMessagesSentToPlayer(), "/wp checkaccess");
+    }
+
+    @Test
+    public void testExecuteListsStatsSubcommand() {
+        when(mockConfigService.getBoolean("rightClickToSelect")).thenReturn(true);
+
+        assertTrue(helpCommand.execute(mockPlayer));
+
+        assertListsSubcommand(captureMessagesSentToPlayer(), "/wp stats");
+    }
+
+    @Test
+    public void testExecuteListsEveryRegisteredSubcommand() {
+        when(mockConfigService.getBoolean("rightClickToSelect")).thenReturn(true);
+
+        assertTrue(helpCommand.execute(mockPlayer));
+
+        List<String> messages = captureMessagesSentToPlayer();
+        String[] subcommands = {"/wp help", "/wp tame", "/wp list", "/wp select", "/wp info",
+                "/wp rename", "/wp wander", "/wp follow", "/wp stay", "/wp call", "/wp locate",
+                "/wp lock", "/wp unlock", "/wp checkaccess", "/wp setfree", "/wp trade",
+                "/wp gather", "/wp stats", "/wp config"};
+        for (String subcommand : subcommands) {
+            assertListsSubcommand(messages, subcommand);
+        }
+    }
+
+    @Test
+    public void testExecuteOmitsBareSelectLineWhenRightClickToSelectIsEnabled() {
+        when(mockConfigService.getBoolean("rightClickToSelect")).thenReturn(true);
+
+        assertTrue(helpCommand.execute(mockPlayer));
+
+        long bareSelectLines = captureMessagesSentToPlayer().stream()
+                .filter(message -> message.contains("/wp select "))
+                .count();
+        assertEquals(1, bareSelectLines);
+    }
+
+    @Test
+    public void testExecuteIncludesBareSelectLineWhenRightClickToSelectIsDisabled() {
+        when(mockConfigService.getBoolean("rightClickToSelect")).thenReturn(false);
+
+        assertTrue(helpCommand.execute(mockPlayer));
+
+        long bareSelectLines = captureMessagesSentToPlayer().stream()
+                .filter(message -> message.contains("/wp select "))
+                .count();
+        assertEquals(2, bareSelectLines);
+    }
+
+    @Test
+    public void testExecuteRejectsNonPlayerSender() {
+        assertFalse(helpCommand.execute(mockConsoleSender));
+
+        verify(mockConsoleSender, never()).sendMessage(anyString());
+    }
+}


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

- `/wp checkaccess` and `/wp stats` are now listed by `HelpCommand.execute`. Both are registered in `WildPets#initializeCommandService` and documented in `COMMANDS.md`, but neither appeared in the in-game help listing, so both were discoverable only by reading the repository documentation.
- `/wp checkaccess` was placed after `/wp unlock` (alongside the other right-click-mode commands) and `/wp stats` before `/wp config`, following the lifecycle ordering the existing listing uses.
- `HelpCommandTest` was added — the first test for a command class — asserting that every registered subcommand appears in the output, that the bare `/wp select` line is gated on `rightClickToSelect`, and that a non-player sender is rejected without output.

## Test plan

- [x] `mvn compile` — clean
- [x] `mvn test` — 38 tests, 0 failures (6 new)
- [x] Regression evidence: with `HelpCommand.java` stashed, `testExecuteListsCheckAccessSubcommand`, `testExecuteListsStatsSubcommand`, and `testExecuteListsEveryRegisteredSubcommand` fail; with the change restored, all pass.
- [x] Documentation sources of truth (`README.md`, `USER_GUIDE.md`, `COMMANDS.md`, `CONFIG.md`, `plugin.yml`) were re-checked against this change — `COMMANDS.md` already documents both subcommands and no document reproduces the help output verbatim, so no documentation update is required.

Closes #305

## Known interaction

`wp.checkaccess` is not declared in `plugin.yml`, so it currently defaults to operators only (see #304). Listing the subcommand in `/wp help` therefore advertises it to players who cannot yet run it — the same situation `/wp stay` is already in. Resolving #304 clears this; no behavior regression is introduced here.

## Issues deferred this cycle

- #304 (`wp.stay` / `wp.checkaccess` missing from `plugin.yml`) — deferred: `plugin.yml` is the permission surface consumed by live servers and the issue itself calls for a deliberate human decision on the chosen defaults, so it is not eligible for autonomous change.
- #283 (Upgrade Command), #265 (configurable/translatable messages), #258 (custom bStats metrics for config values), #250 (cancel vanilla pet teleportation while wandering), #249 (AI-based mob following) — deferred: each is feature work well beyond a polish-sized PR and none shares a subsystem with the change above.

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

---

_drafted by Claude on behalf of Daniel Stephenson_