### PR TITLE
test: cover pet list and pet record repositories

### DIFF
--- a/src/test/java/dansplugins/wildpets/pet/list/PetListRepositoryTest.java
+++ b/src/test/java/dansplugins/wildpets/pet/list/PetListRepositoryTest.java
@@ -1,0 +1,287 @@
+package dansplugins.wildpets.pet.list;
+
+import dansplugins.wildpets.config.ConfigService;
+import dansplugins.wildpets.helpers.ServerProvider;
+import dansplugins.wildpets.pet.Pet;
+import org.bukkit.EntityEffect;
+import org.bukkit.Location;
+import org.bukkit.Server;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Mob;
+import org.bukkit.entity.Player;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class PetListRepositoryTest {
+    @Mock
+    private ConfigService mockConfigService;
+
+    @Mock
+    private ServerProvider mockServerProvider;
+
+    @Mock
+    private Server mockServer;
+
+    @Mock
+    private Player mockPlayer;
+
+    @Mock
+    private Mob mockMob;
+
+    private UUID playerUUID;
+    private UUID entityUUID;
+    private PetListRepository petListRepository;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(mockServerProvider.get()).thenReturn(mockServer);
+        when(mockServer.getEntity(any(UUID.class))).thenReturn(null);
+        when(mockConfigService.getInt("petLimit")).thenReturn(10);
+
+        playerUUID = UUID.randomUUID();
+        entityUUID = UUID.randomUUID();
+        when(mockPlayer.getUniqueId()).thenReturn(playerUUID);
+        when(mockPlayer.getName()).thenReturn("Daniel");
+        when(mockMob.getUniqueId()).thenReturn(entityUUID);
+        when(mockMob.getLocation()).thenReturn(new Location(null, 10.9, 64.2, -3.5));
+
+        petListRepository = new PetListRepository(mockConfigService);
+    }
+
+    @Test
+    public void testInitializeEmptyRepository() {
+        // verify
+        assertTrue(petListRepository.getPetLists().isEmpty());
+        assertTrue(petListRepository.getAllPets().isEmpty());
+        assertTrue(petListRepository.hasNoTrackedPets());
+    }
+
+    @Test
+    public void testCreatePetListForPlayer() {
+        // execute
+        PetList petList = petListRepository.createPetListForPlayer(playerUUID);
+
+        // verify
+        assertEquals(playerUUID, petList.getOwnerUUID());
+        assertEquals(1, petListRepository.getPetLists().size());
+        assertSame(petList, petListRepository.getPetList(playerUUID));
+    }
+
+    @Test
+    public void testGetPetListReturnsNullForUnknownPlayer() {
+        // verify
+        assertNull(petListRepository.getPetList(UUID.randomUUID()));
+    }
+
+    @Test
+    public void testAddNewPetRegistersPetAndPreparesEntity() {
+        // prepare
+        petListRepository.createPetListForPlayer(playerUUID);
+
+        // execute
+        boolean added = petListRepository.addNewPet(mockPlayer, mockMob);
+
+        // verify
+        assertTrue(added);
+        assertFalse(petListRepository.hasNoTrackedPets());
+        assertEquals(1, petListRepository.getPetList(playerUUID).getNumPets());
+
+        Pet pet = petListRepository.getPet(mockMob);
+        assertNotNull(pet);
+        assertEquals(entityUUID, pet.getUniqueID());
+        assertEquals(playerUUID, pet.getOwnerUUID());
+        assertEquals("Daniel's_Pet", pet.getName());
+        // The Bukkit location is truncated toward zero when stored as a WpLocation
+        assertEquals(10, pet.getLastKnownLocation().getX());
+        assertEquals(64, pet.getLastKnownLocation().getY());
+        assertEquals(-3, pet.getLastKnownLocation().getZ());
+
+        verify(mockMob).setCustomName(contains("Daniel's_Pet"));
+        verify(mockMob).setPersistent(true);
+        verify(mockMob).setRemoveWhenFarAway(false);
+        verify(mockMob).playEffect(EntityEffect.LOVE_HEARTS);
+    }
+
+    @Test
+    public void testGetPetReturnsNullForUntrackedEntity() {
+        // prepare
+        Entity untrackedEntity = mock(Entity.class);
+        when(untrackedEntity.getUniqueId()).thenReturn(UUID.randomUUID());
+
+        // verify
+        assertNull(petListRepository.getPet(untrackedEntity));
+    }
+
+    @Test
+    public void testAddExistingPetCreatesMissingPetList() {
+        // prepare
+        Pet pet = createPet(playerUUID, "Daniel");
+
+        // execute
+        petListRepository.addExistingPet(pet);
+
+        // verify
+        assertNotNull(petListRepository.getPetList(playerUUID));
+        assertSame(pet, petListRepository.getPetList(playerUUID).getPet(pet.getUniqueID()));
+        assertFalse(petListRepository.hasNoTrackedPets());
+    }
+
+    @Test
+    public void testAddExistingPetReusesPetList() {
+        // prepare
+        PetList petList = petListRepository.createPetListForPlayer(playerUUID);
+
+        // execute
+        petListRepository.addExistingPet(createPet(playerUUID, "Daniel"));
+        petListRepository.addExistingPet(createPet(playerUUID, "Daniel"));
+
+        // verify
+        assertEquals(1, petListRepository.getPetLists().size());
+        assertEquals(2, petList.getNumPets());
+    }
+
+    @Test
+    public void testGetAllPetsSpansEveryPetList() {
+        // prepare
+        UUID otherPlayerUUID = UUID.randomUUID();
+        Pet firstPet = createPet(playerUUID, "Daniel");
+        Pet secondPet = createPet(otherPlayerUUID, "Other");
+        petListRepository.addExistingPet(firstPet);
+        petListRepository.addExistingPet(secondPet);
+
+        // execute & verify
+        assertEquals(2, petListRepository.getAllPets().size());
+        assertTrue(petListRepository.getAllPets().contains(firstPet));
+        assertTrue(petListRepository.getAllPets().contains(secondPet));
+    }
+
+    @Test
+    public void testGetPlayersPetByEntityAndByName() {
+        // prepare
+        Pet pet = createPet(playerUUID, "Daniel");
+        petListRepository.addExistingPet(pet);
+        Entity petEntity = mock(Entity.class);
+        when(petEntity.getUniqueId()).thenReturn(pet.getUniqueID());
+
+        // execute & verify
+        assertSame(pet, petListRepository.getPlayersPet(mockPlayer, petEntity));
+        assertSame(pet, petListRepository.getPlayersPet(mockPlayer, "Daniel's_Pet"));
+        assertNull(petListRepository.getPlayersPet(mockPlayer, "Nobodys_Pet"));
+    }
+
+    @Test
+    public void testClearAllEmptiesListsAndIndex() {
+        // prepare
+        petListRepository.addExistingPet(createPet(playerUUID, "Daniel"));
+
+        // execute
+        petListRepository.clearAll();
+
+        // verify
+        assertTrue(petListRepository.getPetLists().isEmpty());
+        assertTrue(petListRepository.hasNoTrackedPets());
+    }
+
+    @Test
+    public void testTransferPetMovesPetAndOwnership() {
+        // prepare
+        UUID newOwnerUUID = UUID.randomUUID();
+        Pet pet = createPet(playerUUID, "Daniel");
+        petListRepository.addExistingPet(pet);
+        petListRepository.createPetListForPlayer(newOwnerUUID);
+
+        // execute
+        boolean transferred = petListRepository.transferPet(pet, newOwnerUUID);
+
+        // verify
+        assertTrue(transferred);
+        assertEquals(0, petListRepository.getPetList(playerUUID).getNumPets());
+        assertEquals(1, petListRepository.getPetList(newOwnerUUID).getNumPets());
+        assertEquals(newOwnerUUID, pet.getOwnerUUID());
+        assertTrue(pet.hasAccess(newOwnerUUID));
+        assertFalse(pet.hasAccess(playerUUID));
+    }
+
+    @Test
+    public void testTransferPetCreatesPetListForRecipientWithoutOne() {
+        // prepare
+        UUID newOwnerUUID = UUID.randomUUID();
+        Pet pet = createPet(playerUUID, "Daniel");
+        petListRepository.addExistingPet(pet);
+
+        // execute
+        boolean transferred = petListRepository.transferPet(pet, newOwnerUUID);
+
+        // verify
+        assertTrue(transferred);
+        assertNotNull(petListRepository.getPetList(newOwnerUUID));
+        assertSame(pet, petListRepository.getPetList(newOwnerUUID).getPet(pet.getUniqueID()));
+    }
+
+    @Test
+    public void testTransferPetKeepsEntityIndexIntact() {
+        // prepare
+        UUID newOwnerUUID = UUID.randomUUID();
+        Pet pet = createPet(playerUUID, "Daniel");
+        petListRepository.addExistingPet(pet);
+        Entity petEntity = mock(Entity.class);
+        when(petEntity.getUniqueId()).thenReturn(pet.getUniqueID());
+
+        // execute
+        petListRepository.transferPet(pet, newOwnerUUID);
+
+        // verify - the entity UUID index is keyed by entity, so it survives an ownership change
+        assertSame(pet, petListRepository.getPet(petEntity));
+    }
+
+    @Test
+    public void testTransferPetRollsBackWhenRecipientIsAtPetLimit() {
+        // prepare
+        when(mockConfigService.getInt("petLimit")).thenReturn(1);
+        UUID newOwnerUUID = UUID.randomUUID();
+        Pet pet = createPet(playerUUID, "Daniel");
+        petListRepository.addExistingPet(pet);
+        petListRepository.addExistingPet(createPet(newOwnerUUID, "Other"));
+
+        // execute
+        boolean transferred = petListRepository.transferPet(pet, newOwnerUUID);
+
+        // verify - the pet stays with its original owner and keeps its original access list
+        assertFalse(transferred);
+        assertEquals(1, petListRepository.getPetList(playerUUID).getNumPets());
+        assertSame(pet, petListRepository.getPetList(playerUUID).getPet(pet.getUniqueID()));
+        assertEquals(1, petListRepository.getPetList(newOwnerUUID).getNumPets());
+        assertEquals(playerUUID, pet.getOwnerUUID());
+        assertTrue(pet.hasAccess(playerUUID));
+    }
+
+    @Test
+    public void testTransferPetFailsWhenPetIsNotInItsOwnersList() {
+        // prepare - the pet claims an owner that has no pet list at all
+        Pet pet = createPet(UUID.randomUUID(), "Ghost");
+
+        // execute & verify
+        assertFalse(petListRepository.transferPet(pet, playerUUID));
+    }
+
+    @Test
+    public void testRemovePetReturnsFalseWhenOwnerHasNoPetList() {
+        // prepare
+        Pet pet = createPet(UUID.randomUUID(), "Ghost");
+
+        // execute & verify
+        assertFalse(petListRepository.removePet(pet));
+    }
+
+    private Pet createPet(UUID ownerUUID, String ownerName) {
+        return new Pet(UUID.randomUUID(), ownerUUID, ownerName, mockServerProvider);
+    }
+}

--- a/src/test/java/dansplugins/wildpets/pet/list/PetListTest.java
+++ b/src/test/java/dansplugins/wildpets/pet/list/PetListTest.java
@@ -102,11 +102,10 @@ public class PetListTest {
         // execute
         boolean removed = petList.removePetForTransfer(pet);
 
-        // verify
+        // verify - reaching this point at all shows no entity lookup happened: unlike
+        // removePet, this path never calls Bukkit.getEntity, which would throw under test
         assertTrue(removed);
         assertEquals(0, petList.getNumPets());
-        // The entity is never resolved, so its name/persistence/invulnerability are untouched
-        verify(mockServer, never()).getEntity(pet.getUniqueID());
     }
 
     @Test

--- a/src/test/java/dansplugins/wildpets/pet/list/PetListTest.java
+++ b/src/test/java/dansplugins/wildpets/pet/list/PetListTest.java
@@ -1,0 +1,175 @@
+package dansplugins.wildpets.pet.list;
+
+import dansplugins.wildpets.config.ConfigService;
+import dansplugins.wildpets.helpers.ServerProvider;
+import dansplugins.wildpets.pet.Pet;
+import org.bukkit.Server;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class PetListTest {
+    @Mock
+    private ConfigService mockConfigService;
+
+    @Mock
+    private ServerProvider mockServerProvider;
+
+    @Mock
+    private Server mockServer;
+
+    private UUID ownerUUID;
+    private PetList petList;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(mockServerProvider.get()).thenReturn(mockServer);
+        when(mockServer.getEntity(any(UUID.class))).thenReturn(null);
+
+        ownerUUID = UUID.randomUUID();
+        petList = new PetList(mockConfigService, ownerUUID);
+    }
+
+    @Test
+    public void testInitializeEmptyList() {
+        // verify
+        assertEquals(ownerUUID, petList.getOwnerUUID());
+        assertTrue(petList.getPets().isEmpty());
+        assertEquals(0, petList.getNumPets());
+    }
+
+    @Test
+    public void testAddPetIncreasesCount() {
+        // prepare
+        Pet pet = createPet("Daniel");
+
+        // execute
+        petList.addPet(pet);
+
+        // verify
+        assertEquals(1, petList.getNumPets());
+        assertTrue(petList.getPets().contains(pet));
+    }
+
+    @Test
+    public void testGetPetByUniqueID() {
+        // prepare
+        Pet pet = createPet("Daniel");
+        petList.addPet(pet);
+
+        // execute & verify
+        assertSame(pet, petList.getPet(pet.getUniqueID()));
+        assertNull(petList.getPet(UUID.randomUUID()));
+    }
+
+    @Test
+    public void testGetPetByNameIsCaseInsensitive() {
+        // prepare
+        Pet pet = createPet("Daniel");
+        petList.addPet(pet);
+
+        // execute & verify
+        assertSame(pet, petList.getPet("Daniel's_Pet"));
+        assertSame(pet, petList.getPet("daniel'S_pEt"));
+        assertNull(petList.getPet("Somebody_Elses_Pet"));
+    }
+
+    @Test
+    public void testIsNameTakenIsCaseInsensitive() {
+        // prepare
+        Pet pet = createPet("Daniel");
+        petList.addPet(pet);
+
+        // execute & verify
+        assertTrue(petList.isNameTaken(pet.getName()));
+        assertTrue(petList.isNameTaken(pet.getName().toUpperCase()));
+        assertFalse(petList.isNameTaken("Unclaimed_Name"));
+    }
+
+    @Test
+    public void testRemovePetForTransferLeavesEntityStateAlone() {
+        // prepare
+        Pet pet = createPet("Daniel");
+        petList.addPet(pet);
+
+        // execute
+        boolean removed = petList.removePetForTransfer(pet);
+
+        // verify
+        assertTrue(removed);
+        assertEquals(0, petList.getNumPets());
+        // The entity is never resolved, so its name/persistence/invulnerability are untouched
+        verify(mockServer, never()).getEntity(pet.getUniqueID());
+    }
+
+    @Test
+    public void testRemovePetForTransferReturnsFalseWhenPetAbsent() {
+        // prepare
+        Pet pet = createPet("Daniel");
+
+        // execute & verify
+        assertFalse(petList.removePetForTransfer(pet));
+    }
+
+    @Test
+    public void testGetFollowingPetsOnlyReturnsFollowers() {
+        // prepare
+        Pet follower = createPet("Follower");
+        follower.setFollowing();
+        Pet wanderer = createPet("Wanderer");
+        Pet stayer = createPet("Stayer");
+        stayer.setStaying();
+        petList.addPet(follower);
+        petList.addPet(wanderer);
+        petList.addPet(stayer);
+
+        // execute & verify
+        assertEquals(1, petList.getFollowingPets().size());
+        assertSame(follower, petList.getFollowingPets().get(0));
+    }
+
+    @Test
+    public void testGetNewIDIsWithinRangeAndUnused() {
+        // prepare
+        when(mockConfigService.getInt("petLimit")).thenReturn(10);
+        Pet pet = createPet("Daniel");
+        pet.setAssignedID(5);
+        petList.addPet(pet);
+
+        // execute
+        int newID = petList.getNewID();
+
+        // verify
+        assertTrue(newID >= 0);
+        assertTrue(newID < 100); // petLimit * 10
+        assertNotEquals(5, newID);
+    }
+
+    @Test
+    public void testGetNewIDNeverCollidesWithExistingIDs() {
+        // prepare - a petLimit of 1 leaves only IDs 0-9, so collisions are likely
+        when(mockConfigService.getInt("petLimit")).thenReturn(1);
+        for (int assignedID = 0; assignedID < 9; assignedID++) {
+            Pet pet = createPet("Owner" + assignedID);
+            pet.setAssignedID(assignedID);
+            petList.addPet(pet);
+        }
+
+        // execute - the only remaining free ID is 9
+        int newID = petList.getNewID();
+
+        // verify
+        assertEquals(9, newID);
+    }
+
+    private Pet createPet(String ownerName) {
+        return new Pet(UUID.randomUUID(), ownerUUID, ownerName, mockServerProvider);
+    }
+}

--- a/src/test/java/dansplugins/wildpets/pet/record/PetRecordRepositoryTest.java
+++ b/src/test/java/dansplugins/wildpets/pet/record/PetRecordRepositoryTest.java
@@ -1,0 +1,140 @@
+package dansplugins.wildpets.pet.record;
+
+import dansplugins.wildpets.exceptions.PetRecordNotFoundException;
+import dansplugins.wildpets.helpers.ServerProvider;
+import dansplugins.wildpets.pet.Pet;
+import org.bukkit.Server;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class PetRecordRepositoryTest {
+    @Mock
+    private ServerProvider mockServerProvider;
+
+    @Mock
+    private Server mockServer;
+
+    private UUID entityUUID;
+    private Pet pet;
+    private PetRecordRepository petRecordRepository;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(mockServerProvider.get()).thenReturn(mockServer);
+        when(mockServer.getEntity(any(UUID.class))).thenReturn(null);
+
+        entityUUID = UUID.randomUUID();
+        pet = new Pet(entityUUID, UUID.randomUUID(), "Daniel", mockServerProvider);
+        pet.setAssignedID(42);
+        petRecordRepository = new PetRecordRepository();
+    }
+
+    @Test
+    public void testInitializeEmptyRepository() {
+        // verify
+        assertTrue(petRecordRepository.getPetRecords().isEmpty());
+    }
+
+    @Test
+    public void testAddPetRecord() throws PetRecordNotFoundException {
+        // execute
+        boolean added = petRecordRepository.addPetRecord(pet);
+
+        // verify
+        assertTrue(added);
+        assertEquals(1, petRecordRepository.getPetRecords().size());
+        assertEquals(42, petRecordRepository.getPetRecord(entityUUID).getAssignedID());
+    }
+
+    @Test(expected = PetRecordNotFoundException.class)
+    public void testGetPetRecordThrowsWhenAbsent() throws PetRecordNotFoundException {
+        // execute
+        petRecordRepository.getPetRecord(UUID.randomUUID());
+    }
+
+    @Test
+    public void testRemovePetRecord() {
+        // prepare
+        petRecordRepository.addPetRecord(pet);
+
+        // execute
+        boolean removed = petRecordRepository.removePetRecord(entityUUID);
+
+        // verify
+        assertTrue(removed);
+        assertTrue(petRecordRepository.getPetRecords().isEmpty());
+    }
+
+    @Test
+    public void testRemovePetRecordReturnsFalseWhenAbsent() {
+        // prepare
+        petRecordRepository.addPetRecord(pet);
+
+        // execute & verify
+        assertFalse(petRecordRepository.removePetRecord(UUID.randomUUID()));
+        assertEquals(1, petRecordRepository.getPetRecords().size());
+    }
+
+    @Test
+    public void testRemovePetRecordOnlyRemovesTheMatchingRecord() throws PetRecordNotFoundException {
+        // prepare
+        Pet otherPet = new Pet(UUID.randomUUID(), UUID.randomUUID(), "Other", mockServerProvider);
+        petRecordRepository.addPetRecord(pet);
+        petRecordRepository.addPetRecord(otherPet);
+
+        // execute
+        petRecordRepository.removePetRecord(entityUUID);
+
+        // verify
+        assertEquals(1, petRecordRepository.getPetRecords().size());
+        assertEquals(otherPet.getUniqueID(), petRecordRepository.getPetRecord(otherPet.getUniqueID()).getUniqueID());
+    }
+
+    @Test
+    public void testGetOrCreatePetRecordCreatesWhenAbsent() throws PetRecordNotFoundException {
+        // execute
+        PetRecord record = petRecordRepository.getOrCreatePetRecord(pet);
+
+        // verify
+        assertEquals(entityUUID, record.getUniqueID());
+        assertEquals(1, petRecordRepository.getPetRecords().size());
+    }
+
+    @Test
+    public void testGetOrCreatePetRecordReturnsExistingRecord() throws PetRecordNotFoundException {
+        // prepare - an existing record whose state has since diverged from the live pet
+        petRecordRepository.addPetRecord(pet);
+        petRecordRepository.getPetRecord(entityUUID).setName("Stored_Name");
+        pet.setName("Live_Name");
+
+        // execute
+        PetRecord record = petRecordRepository.getOrCreatePetRecord(pet);
+
+        // verify - the stored record wins; no second record is created
+        assertEquals("Stored_Name", record.getName());
+        assertEquals(1, petRecordRepository.getPetRecords().size());
+    }
+
+    @Test
+    public void testAddPetRecordTwiceStoresDuplicateRecords() {
+        // Characterization of current behaviour: PetRecord overrides equals() but not
+        // hashCode(), so the backing HashSet cannot detect that two records describe the
+        // same entity and stores both. Tracked separately as a bug, not fixed here.
+
+        // execute
+        petRecordRepository.addPetRecord(pet);
+        boolean addedAgain = petRecordRepository.addPetRecord(pet);
+
+        // verify
+        assertTrue(addedAgain);
+        assertEquals(2, petRecordRepository.getPetRecords().size());
+    }
+}

--- a/src/test/java/dansplugins/wildpets/pet/record/PetRecordTest.java
+++ b/src/test/java/dansplugins/wildpets/pet/record/PetRecordTest.java
@@ -1,0 +1,128 @@
+package dansplugins.wildpets.pet.record;
+
+import dansplugins.wildpets.helpers.ServerProvider;
+import dansplugins.wildpets.pet.Pet;
+import org.bukkit.Server;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class PetRecordTest {
+    @Mock
+    private ServerProvider mockServerProvider;
+
+    @Mock
+    private Server mockServer;
+
+    private UUID entityUUID;
+    private UUID ownerUUID;
+    private Pet pet;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(mockServerProvider.get()).thenReturn(mockServer);
+        when(mockServer.getEntity(any(UUID.class))).thenReturn(null);
+
+        entityUUID = UUID.randomUUID();
+        ownerUUID = UUID.randomUUID();
+        pet = new Pet(entityUUID, ownerUUID, "Daniel", mockServerProvider);
+        pet.setAssignedID(42);
+    }
+
+    @Test
+    public void testInitializeFromPet() {
+        // execute
+        PetRecord petRecord = new PetRecord(pet);
+
+        // verify
+        assertEquals(entityUUID, petRecord.getUniqueID());
+        assertEquals(ownerUUID, petRecord.getOwnerUUID());
+        assertEquals(42, petRecord.getAssignedID());
+        assertEquals("Daniel's_Pet", petRecord.getName());
+    }
+
+    @Test
+    public void testSaveToJson() {
+        // prepare
+        PetRecord petRecord = new PetRecord(pet);
+
+        // execute
+        Map<String, String> data = petRecord.save();
+
+        // verify
+        assertEquals("\"" + entityUUID + "\"", data.get("uniqueID"));
+        assertEquals("\"" + ownerUUID + "\"", data.get("owner"));
+        assertEquals("42", data.get("assignedID"));
+        assertEquals("\"Daniel\\u0027s_Pet\"", data.get("name"));
+    }
+
+    @Test
+    public void testSaveAndLoadRoundTrip() {
+        // prepare
+        Map<String, String> data = new PetRecord(pet).save();
+
+        // execute
+        PetRecord loadedRecord = new PetRecord(data);
+
+        // verify
+        assertEquals(entityUUID, loadedRecord.getUniqueID());
+        assertEquals(ownerUUID, loadedRecord.getOwnerUUID());
+        assertEquals(42, loadedRecord.getAssignedID());
+        assertEquals("Daniel's_Pet", loadedRecord.getName());
+    }
+
+    @Test
+    public void testSetters() {
+        // prepare
+        PetRecord petRecord = new PetRecord(pet);
+        UUID newUniqueID = UUID.randomUUID();
+        UUID newOwnerUUID = UUID.randomUUID();
+
+        // execute
+        petRecord.setUniqueID(newUniqueID);
+        petRecord.setOwnerUUID(newOwnerUUID);
+        petRecord.setAssignedID(7);
+        petRecord.setName("Renamed_Pet");
+
+        // verify
+        assertEquals(newUniqueID, petRecord.getUniqueID());
+        assertEquals(newOwnerUUID, petRecord.getOwnerUUID());
+        assertEquals(7, petRecord.getAssignedID());
+        assertEquals("Renamed_Pet", petRecord.getName());
+    }
+
+    @Test
+    public void testEqualityIsBasedOnUniqueIDAlone() {
+        // prepare
+        PetRecord petRecord = new PetRecord(pet);
+        PetRecord sameEntityRecord = new PetRecord(pet);
+        sameEntityRecord.setName("A_Different_Name");
+        sameEntityRecord.setOwnerUUID(UUID.randomUUID());
+        sameEntityRecord.setAssignedID(99);
+
+        PetRecord otherEntityRecord = new PetRecord(pet);
+        otherEntityRecord.setUniqueID(UUID.randomUUID());
+
+        // verify
+        assertEquals(petRecord, sameEntityRecord);
+        assertNotEquals(petRecord, otherEntityRecord);
+    }
+
+    @Test
+    public void testEqualityAgainstNullAndOtherTypes() {
+        // prepare
+        PetRecord petRecord = new PetRecord(pet);
+
+        // verify
+        assertNotEquals(null, petRecord);
+        assertNotEquals("not a pet record", petRecord);
+    }
+}


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

Characterization tests are added for the four previously untested classes in the `pet.list` and `pet.record` packages. No production code is changed by this PR.

- `PetListTest` — lookup by UUID and by name (case-insensitive), `addPet`, `removePetForTransfer`, `getFollowingPets`, and `getNewID`'s collision avoidance.
- `PetListRepositoryTest` — list creation and lookup, `addNewPet`'s entity preparation and location truncation, `addExistingPet`, `clearAll`, `getAllPets`, `getPlayersPet`, and every branch of `transferPet` including the rollback taken when the recipient is at the pet limit.
- `PetRecordTest` — construction from a `Pet`, the JSON save shape, the save/load round trip, the setters, and the `uniqueID`-only equality contract.
- `PetRecordRepositoryTest` — add, remove, `getPetRecord`'s not-found exception, and both branches of `getOrCreatePetRecord`.

Collaborators are mocked through the existing `ServerProvider` seam and `ConfigService`, matching the pattern established in `PetTest`. No real Bukkit API is called.

The suite goes from 38 tests to 79.

## Bugs found and deliberately not fixed here

This cycle was scoped to test expansion, so current behaviour is pinned rather than corrected. Three issues were filed instead:

- #309 — `PetRecord` overrides `equals()` without `hashCode()`, so `PetRecordRepository`'s `HashSet` stores duplicate records. Pinned by `testAddPetRecordTwiceStoresDuplicateRecords`, which is commented as a characterization test to be inverted when the bug is fixed.
- #310 — `StorageService.loadPetRecords()` discards everything it parses, so pet records are never restored from disk.
- #311 — `PetList` calls `Bukkit` statics directly instead of using the `ServerProvider` seam, which is why `PetList.removePet` and `sendListOfPetsToPlayer` are not covered by this PR.

## Test plan

- [x] `mvn test` — 79 tests, 0 failures, 0 errors.
- [x] Mutation spot-check: the rollback in `transferPet` was removed and `transferOwnershipTo` was downgraded to a bare `setOwnerUUID`; `testTransferPetRollsBackWhenRecipientIsAtPetLimit` and `testTransferPetMovesPetAndOwnership` both failed, and both passed again once reverted.
- [x] Mutation spot-check: `PetList`'s name comparison was made case-sensitive, `getFollowingPets`' predicate was widened, and `isIDTaken` was stubbed to `false`; the three corresponding tests failed and passed again once reverted.

## Deferred backlog

The open issues not picked up this cycle, with reasons: #304 (declaring `wp.stay` and `wp.checkaccess` in `plugin.yml`) is blocked on a human decision about the intended permission defaults, as recorded on that issue; #283, #265, #249 and #250 are feature work too large for a single polish-sized PR; #258 (bStats metrics for config values) is feasible but was passed over in favour of raising confidence in the untested pet-ownership data structures first.

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

---

_drafted by Claude on behalf of Daniel Stephenson_